### PR TITLE
Example script for deployment of application gateway service

### DIFF
--- a/Deploy-ApplicationGateway.ps1
+++ b/Deploy-ApplicationGateway.ps1
@@ -1,0 +1,61 @@
+# Example script
+# Creates Application Gateway with additional resources and adds ConnectedWebAppName to backend pools of the app gateway
+param (
+    [Parameter(Mandatory=$true)][string]$AppGatewayName,
+    [Parameter(Mandatory=$true)][string]$SubnetToCreate,
+    [Parameter(Mandatory=$true)][string]$VnetToCreate,
+    [Parameter(Mandatory=$true)][string]$PublicIpToCreate,
+    [Parameter(Mandatory=$true)][string]$Location,
+    [Parameter(Mandatory=$true)][string]$ResourceGroupName,
+    [Parameter(Mandatory=$true)][string]$ConnectedWebAppResourceGroupName,    
+    [Parameter(Mandatory=$true)][string]$ConnectedWebAppName
+)
+
+
+$webapp = Get-AzureRmWebApp -ResourceGroupName $ConnectedWebAppResourceGroupName -Name $ConnectedWebAppName
+#New-AzureRmWebApp -ResourceGroupName $rg.ResourceGroupName -Name $webappname -Location EastUs -AppServicePlan $webappname
+
+# Creates a subnet for the application gateway
+$subnet = New-AzureRmVirtualNetworkSubnetConfig -Name $SubnetToCreate -AddressPrefix 10.0.0.0/24
+
+# Creates a vnet for the application gateway
+$vnet = New-AzureRmVirtualNetwork -Name $VnetToCreate -ResourceGroupName $ResourceGroupName -Location $Location -AddressPrefix 10.0.0.0/16 -Subnet $subnet
+
+# Retrieve the subnet object for use later
+$subnet=$vnet.Subnets[0]
+
+# Create a public IP address
+$publicip = New-AzureRmPublicIpAddress -ResourceGroupName $ResourceGroupName -name $PublicIpToCreate -location $Location -AllocationMethod Dynamic
+
+# Create a new IP configuration
+$gipconfig = New-AzureRmApplicationGatewayIPConfiguration -Name gatewayIP01 -Subnet $subnet
+
+# Create a backend pool with the hostname of the web app
+$pool = New-AzureRmApplicationGatewayBackendAddressPool -Name appGatewayBackendPool -BackendFqdns $webapp.HostNames
+
+# Define the status codes to match for the probe
+$match = New-AzureRmApplicationGatewayProbeHealthResponseMatch -StatusCode 200-399
+
+# Create a probe with the PickHostNameFromBackendHttpSettings switch for web apps
+$probeconfig = New-AzureRmApplicationGatewayProbeConfig -name webappprobe -Protocol Http -Path / -Interval 30 -Timeout 120 -UnhealthyThreshold 3 -PickHostNameFromBackendHttpSettings -Match $match
+
+# Define the backend http settings
+$poolSetting = New-AzureRmApplicationGatewayBackendHttpSettings -Name appGatewayBackendHttpSettings -Port 80 -Protocol Http -CookieBasedAffinity Disabled -RequestTimeout 120 -PickHostNameFromBackendAddress -Probe $probeconfig
+
+# Create a new front-end port
+$fp = New-AzureRmApplicationGatewayFrontendPort -Name frontendport01  -Port 80
+
+# Create a new front end IP configuration
+$fipconfig = New-AzureRmApplicationGatewayFrontendIPConfig -Name fipconfig01 -PublicIPAddress $publicip
+
+# Create a new listener using the front-end ip configuration and port created earlier
+$listener = New-AzureRmApplicationGatewayHttpListener -Name listener01 -Protocol Http -FrontendIPConfiguration $fipconfig -FrontendPort $fp
+
+# Create a new rule
+$rule = New-AzureRmApplicationGatewayRequestRoutingRule -Name rule01 -RuleType Basic -BackendHttpSettings $poolSetting -HttpListener $listener -BackendAddressPool $pool 
+
+# Define the application gateway SKU to use
+$sku = New-AzureRmApplicationGatewaySku -Name Standard_Small -Tier Standard -Capacity 2
+
+# Create the application gateway
+$appgw = New-AzureRmApplicationGateway -Name $AppGatewayName -ResourceGroupName $ResourceGroupName -Location $Location -BackendAddressPools $pool -BackendHttpSettingsCollection $poolSetting -Probes $probeconfig -FrontendIpConfigurations $fipconfig  -GatewayIpConfigurations $gipconfig -FrontendPorts $fp -HttpListeners $listener -RequestRoutingRules $rule -Sku $sku


### PR DESCRIPTION
Example script that can be used for deployment of the application gateway. The script creates app gateway with additional required resources (Vnet, public IP etc.) and adds the web app (that should be passed in parameters) to the back-end list of the application gateway. Application gateway then forwards HTTP (port 80) requests to that web app.
This script can be used as starting point for the deployment of the application gateway.